### PR TITLE
Validate keyword locations

### DIFF
--- a/include/ast/passes/control_flow.h
+++ b/include/ast/passes/control_flow.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ast/passes/pass.h"
+
+class ControlFlow : public Pass {
+   private:
+    bool in_function;
+    bool in_loop;
+
+   public:
+    ControlFlow();
+    void visit_function(shared_ptr<ast::Function>) override;
+    void visit_return(shared_ptr<ast::Return>) override;
+    void visit_loop(shared_ptr<ast::Loop>) override;
+    void visit_continue(shared_ptr<ast::Continue>) override;
+    void visit_break(shared_ptr<ast::Break>) override;
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/ast/passes/def_ref.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/ast/passes/type_check.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/ast/passes/builtin.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ast/passes/control_flow.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/shared/type/type.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/shared/type/character.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/shared/type/integer.cpp"

--- a/src/ast/passes/control_flow.cpp
+++ b/src/ast/passes/control_flow.cpp
@@ -1,0 +1,48 @@
+#include "ast/passes/control_flow.h"
+#include "errors/errors.h"
+
+ControlFlow::ControlFlow() : Pass("Control Flow") {
+    this->in_function = false;
+    this->in_loop = false;
+}
+
+void ControlFlow::visit_function(shared_ptr<ast::Function> node) {
+    for (const auto& param : node->params) {
+        visit(param);
+    }
+
+    in_function = true;
+    visit(node->body);
+    in_function = false;
+}
+
+void ControlFlow::visit_return(shared_ptr<ast::Return> node) {
+    if (!in_function) {
+        throw SyntaxError(node->token->getLine(),
+                          "found `return` outside of function");
+    }
+    visit(node->expr);
+}
+
+void ControlFlow::visit_loop(shared_ptr<ast::Loop> node) {
+    in_loop = true;
+    visit(node->variable);
+    visit(node->condition);
+    visit(node->assignment);
+    visit(node->body);
+    in_loop = false;
+}
+
+void ControlFlow::visit_continue(shared_ptr<ast::Continue> node) {
+    if (!in_loop) {
+        throw SyntaxError(node->token->getLine(),
+                          "found `continue` outside of loop");
+    }
+}
+
+void ControlFlow::visit_break(shared_ptr<ast::Break> node) {
+    if (!in_loop) {
+        throw SyntaxError(node->token->getLine(),
+                          "found `break` outside of loop");
+    }
+}

--- a/src/ast/passes/pass.cpp
+++ b/src/ast/passes/pass.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/pass.h"
 #include "ast/ast.h"
 #include "ast/passes/builtin.h"
+#include "ast/passes/control_flow.h"
 #include "ast/passes/def_ref.h"
 #include "ast/passes/type_check.h"
 
@@ -13,6 +14,7 @@ constexpr bool debug = false;
 void Pass::run_passes(std::shared_ptr<ast::Block> ast,
                       shared_ptr<SymbolTable> symtab) {
     std::vector<std::shared_ptr<Pass>> passes = {
+        std::make_shared<ControlFlow>(),
         std::make_shared<DefRef>(symtab),
         std::make_shared<TypeCheck>(),
         std::make_shared<Builtin>(symtab),

--- a/tests/input/errors/syntax/break.in
+++ b/tests/input/errors/syntax/break.in
@@ -1,0 +1,5 @@
+fn main(): i32 {
+    break;
+    return 0;
+}
+

--- a/tests/input/errors/syntax/continue.in
+++ b/tests/input/errors/syntax/continue.in
@@ -1,0 +1,4 @@
+fn main(): i32 {
+    continue;
+    return 0;
+}

--- a/tests/input/errors/syntax/return.in
+++ b/tests/input/errors/syntax/return.in
@@ -1,0 +1,5 @@
+return 0;
+
+fn main(): i32 {
+    return 0;
+}

--- a/tests/output/errors/syntax/break.out
+++ b/tests/output/errors/syntax/break.out
@@ -1,0 +1,1 @@
+SyntaxError on Line 2

--- a/tests/output/errors/syntax/continue.out
+++ b/tests/output/errors/syntax/continue.out
@@ -1,0 +1,1 @@
+SyntaxError on Line 2

--- a/tests/output/errors/syntax/return.out
+++ b/tests/output/errors/syntax/return.out
@@ -1,0 +1,1 @@
+SyntaxError on Line 1


### PR DESCRIPTION
ensure that `continue`, `break`, and `return` statement appeared in the correct locations