### PR TITLE
Compile Multiple Files

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+CompileFlags:
+  Add:
+    - "--include-directory=./include"
+    - "--include-directory=./gen/fusion"
+Diagnostics:
+  MissingIncludes: Strict
+  UnusedIncludes: Strict

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/include",
+                "${workspaceFolder}/gen/fusion"
+            ],
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks"
+            ],
+            "intelliSenseMode": "macos-clang-x64",
+            "compilerPath": "/usr/bin/clang++",
+            "cppStandard": "c++20",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "memory": "cpp",
+        "string": "cpp"
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
-set(CMAKE_C_COMPILER "/usr/bin/clang")
-set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
+# set(CMAKE_C_COMPILER "/usr/bin/clang")
+# set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(FusionBase)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.31)
 set(CMAKE_C_COMPILER "/usr/bin/clang")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(FusionBase)
@@ -6,9 +6,11 @@ project(FusionBase)
 
 include(ExternalProject)
 find_package(Git REQUIRED)
-find_package(Java COMPONENTS Runtime REQUIRED) 
+find_package(Java COMPONENTS Runtime REQUIRED)
 
 include("${CMAKE_SOURCE_DIR}/cmake/get_mlir.cmake")
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
+set(CMAKE_C_COMPILER "/usr/bin/clang")
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(FusionBase)
+
 
 include(ExternalProject)
 find_package(Git REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.28)
 set(CMAKE_C_COMPILER "/usr/bin/clang")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 project(FusionBase)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Fusion Lang
+
 A toy language to continue learning antlr4 and mlir/llvm and see where I go
 
 ## Setting up environment
+
 If you are on macos then I have made a simple install script which will install all requirements/dependencies needed to develop with antlr and mlir, located [here](https://github.com/jackparsonss/fusion/blob/main/scipts/setup_macos.bash)
 
 ## Building
+
 ```bash
 mkdir build
 cd build
@@ -13,27 +16,33 @@ make
 ```
 
 ## Running
+
 ```bash
 cd bin
 ./fuse <filename>.fuse
 ```
 
 ## Documentation
+
 ### Declarations
+
 The `let` keyword signifies that the variable can be later changed.
 The `const` keyword signifies that the variable cannot be later changed;
+
 ```
 let x: i32 = 5;
 const y: i32 = x;
 ```
 
 ### Types
+
 - **i32**: 32-bit integer
 - **i64**: 64-bit integer
 - **ch**: 8-bit ascii character
 - **bool**: 1-bit boolean(true/false)
 
 ### Functions
+
 ```
 fn foo(let x: i32, let y: ch): i32 {
     print(x);
@@ -49,8 +58,11 @@ fn main(): i32 {
 ```
 
 #### Builtin Functions
+
 ##### main
+
 Must be defined by the user, is the entry point to the fusion program
+
 ```
 fn main(): i32 {
     // do stuff
@@ -59,20 +71,27 @@ fn main(): i32 {
 ```
 
 ##### print
+
 Prints the argument passed to stdout
+
 ```
 print(5);
 ```
 
 ##### println
+
 Prints the argument passed to stdout with a newline at the end
+
 ```
 println(100);
 ```
+
 ```
+
 ```
 
 #### Arithmetic
+
 - addition: `+`
 - subtraction: `-`
 - power: `^`
@@ -85,6 +104,7 @@ println(100);
 - not equal: `!=`
 - and: `&&`
 - or: `||`
+
 ```
 fn main(): i32 {
     let a: i32 = 5 + 5;
@@ -106,7 +126,9 @@ fn main(): i32 {
 ```
 
 #### Conditionals
+
 Just like `if`/`else` statements in most languages
+
 ```
 let x: i32 = 5;
 if(x == 4){
@@ -117,14 +139,18 @@ if(x == 4){
     println(x);
 }
 ```
+
 Conditions **must** be booleans
 
 #### Loops
+
 Similar to c-style for loops, they are composed of 4 parts
+
 - Variable declaration
 - Loop condition
 - Variable assignment
 - Body
+
 ```
 for(let i: i32 = 0; i < 5; i = i + 1){
     println(i);
@@ -132,5 +158,28 @@ for(let i: i32 = 0; i < 5; i = i + 1){
 ```
 
 Loops also allow for control flow:
+
 - `continue`: goes to the next iteration of the loop
 - `break`: exits the loop early
+
+#### Modules
+
+Fuse's module system follows a simple pattern of the module name is the name of the file. Modules are imported using the `import` keyword followed by the module name.
+
+```
+// foo.fuse
+fn foo(): i32 {
+    println(4);
+
+    return 5;
+}
+
+// main.fuse
+import foo;
+
+fn main(): i32 {
+    println(foo());
+
+    return 0;
+}
+```

--- a/grammar/Fusion.g4
+++ b/grammar/Fusion.g4
@@ -5,6 +5,8 @@ file: topLevel* EOF;
 topLevel
     : function
     | declaration SEMI
+    | module
+    | imp
     ;
 
 statement
@@ -42,6 +44,10 @@ else: ELSE (block | if);
 
 return: RETURN expr SEMI;
 
+module: MODULE ID SEMI;
+
+imp: IMPORT ID SEMI;
+
 expr
     : call                                               #callExpr
     | (op=MINUS | op=BANG) expr                          #unary
@@ -76,6 +82,8 @@ ELSE: 'else';
 FOR: 'for';
 BREAK: 'break';
 CONTINUE: 'continue';
+MODULE: 'module';
+IMPORT: 'import';
 
 // symbols
 SEMI: ';';
@@ -118,6 +126,7 @@ BOOLEAN: ('true' | 'false');
 INT: [0-9]+;
 ID: [a-zA-Z_][a-zA-Z0-9_]*;
 CHARACTER: '\'' ( '\\\\' | '\\0' | '\\a' | '\\b' | '\\t' | '\\n' | '\\r' | '\\"' | '\\\'' | ~[\\'] ) '\'';
+STRING: '"' ( '\\\\' | '\\0' | '\\a' | '\\b' | '\\t' | '\\n' | '\\r' | '\\"' | '\\\'' | ~[\\"] )*? '"';
 
 // skip whitespace
 WS : [ \t\r\n]+ -> skip ;

--- a/include/ast/ast.h
+++ b/include/ast/ast.h
@@ -282,4 +282,11 @@ class Break : public Node {
     Break(Token* token) : Node(token) {}
     void xml(int level);
 };
+
+class Import : public Node {
+   public:
+    std::string name;
+    Import(std::string name, Token* token);
+    void xml(int level);
+};
 }  // namespace ast

--- a/include/ast/builder.h
+++ b/include/ast/builder.h
@@ -7,6 +7,7 @@
 
 #include "ast/ast.h"
 #include "ast/symbol/symbol_table.h"
+#include "module/manager.h"
 
 using std::make_shared;
 using std::shared_ptr;
@@ -16,9 +17,11 @@ class Builder : public FusionBaseVisitor {
    private:
     shared_ptr<ast::Block> ast;
     shared_ptr<SymbolTable> symbol_table;
+    shared_ptr<module::Manager> module_manager;
 
    public:
-    Builder(shared_ptr<SymbolTable> symbol_table);
+    Builder(shared_ptr<SymbolTable> symbol_table,
+            shared_ptr<module::Manager> module_manager);
     bool has_ast();
     shared_ptr<ast::Block> get_ast();
 
@@ -49,4 +52,6 @@ class Builder : public FusionBaseVisitor {
     std::any visitIf(FusionParser::IfContext* ctx) override;
     std::any visitElse(FusionParser::ElseContext* ctx) override;
     std::any visitLoop(FusionParser::LoopContext* ctx) override;
+    std::any visitModule(FusionParser::ModuleContext* ctx) override;
+    std::any visitImp(FusionParser::ImpContext* ctx) override;
 };

--- a/include/ast/builder.h
+++ b/include/ast/builder.h
@@ -9,6 +9,8 @@
 #include "ast/symbol/symbol_table.h"
 #include "module/manager.h"
 
+#include<any>
+
 using std::make_shared;
 using std::shared_ptr;
 using namespace fusion;

--- a/include/ast/passes/pass.h
+++ b/include/ast/passes/pass.h
@@ -33,6 +33,6 @@ class Pass {
     virtual void visit_loop(shared_ptr<ast::Loop>);
     virtual void visit_continue(shared_ptr<ast::Continue>);
     virtual void visit_break(shared_ptr<ast::Break>);
-
+    virtual void visit_import(shared_ptr<ast::Import>);
     static void run_passes(shared_ptr<ast::Block> ast, shared_ptr<SymbolTable>);
 };

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -4,6 +4,7 @@
 #include <ostream>
 #include <stack>
 #include <string>
+#include <unordered_map>
 
 #include "ast/ast.h"
 

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -48,4 +48,5 @@ class Backend {
     mlir::Value visit_loop(shared_ptr<ast::Loop>);
     mlir::Value visit_continue(shared_ptr<ast::Continue>);
     mlir::Value visit_break(shared_ptr<ast::Break>);
+    mlir::Value visit_import(shared_ptr<ast::Import>);
 };

--- a/include/backend/expressions/global.h
+++ b/include/backend/expressions/global.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "ast/ast.h"
 #include "mlir/IR/Value.h"

--- a/include/backend/utils.h
+++ b/include/backend/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "ast/ast.h"
 
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
@@ -7,6 +8,7 @@
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
+#include "shared/type/type.h"
 
 namespace utils {
 mlir::Value stack_allocate(mlir::Type type);

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -12,22 +12,33 @@
 
 using std::shared_ptr, std::unique_ptr;
 
+class Unit {
+   public:
+    antlr4::tree::ParseTree* tree;
+    Unit(std::string filename,
+         LexerErrorListener* lexer_error,
+         SyntaxErrorListener* syntax_error);
+    ~Unit();
+
+   private:
+    antlr4::ANTLRFileStream* file;
+    fusion::FusionLexer* lexer;
+    antlr4::CommonTokenStream* tokens;
+    fusion::FusionParser* parser;
+};
+
 class Compiler {
    private:
     shared_ptr<SymbolTable> symbol_table;
     unique_ptr<Backend> backend;
     unique_ptr<Builder> builder;
 
-    antlr4::ANTLRFileStream* file;
-    fusion::FusionLexer* lexer;
-    antlr4::tree::ParseTree* tree;
-    antlr4::CommonTokenStream* tokens;
-    fusion::FusionParser* parser;
+    std::vector<shared_ptr<Unit>> units;
     LexerErrorListener* lexer_error;
     SyntaxErrorListener* syntax_error;
 
    public:
-    Compiler(std::string filename,
+    Compiler(std::vector<std::string> filenames,
              shared_ptr<SymbolTable> symbol_table,
              unique_ptr<Backend> backend,
              unique_ptr<Builder> builder);

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -2,30 +2,14 @@
 
 #include <memory>
 
-#include "ANTLRFileStream.h"
-#include "FusionLexer.h"
-#include "ParseTree.h"
 #include "ast/builder.h"
 #include "ast/symbol/symbol_table.h"
 #include "backend/backend.h"
 #include "errors/syntax.h"
+#include "module/manager.h"
 
 using std::shared_ptr, std::unique_ptr;
-
-class Unit {
-   public:
-    antlr4::tree::ParseTree* tree;
-    Unit(std::string filename,
-         LexerErrorListener* lexer_error,
-         SyntaxErrorListener* syntax_error);
-    ~Unit();
-
-   private:
-    antlr4::ANTLRFileStream* file;
-    fusion::FusionLexer* lexer;
-    antlr4::CommonTokenStream* tokens;
-    fusion::FusionParser* parser;
-};
+namespace fs = std::filesystem;
 
 class Compiler {
    private:
@@ -33,12 +17,12 @@ class Compiler {
     unique_ptr<Backend> backend;
     unique_ptr<Builder> builder;
 
-    std::vector<shared_ptr<Unit>> units;
+    shared_ptr<module::Unit> entry;
     LexerErrorListener* lexer_error;
     SyntaxErrorListener* syntax_error;
 
    public:
-    Compiler(std::vector<std::string> filenames,
+    Compiler(fs::path entry,
              shared_ptr<SymbolTable> symbol_table,
              unique_ptr<Backend> backend,
              unique_ptr<Builder> builder);

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <string>
 
 #include "ast/builder.h"
 #include "ast/symbol/symbol_table.h"

--- a/include/errors/errors.h
+++ b/include/errors/errors.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <exception>
 #include <ostream>
 #include <sstream>
+#include <string>
 
 class CompileTimeException : public std::exception {
    protected:

--- a/include/errors/syntax.h
+++ b/include/errors/syntax.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <cstddef>
+#include <exception>
+#include <ostream>
+#include <string>
 #include "BaseErrorListener.h"
-#include "antlr4-runtime.h"
+#include "Recognizer.h"
+#include "Token.h"
 
 #define _NC "\033[0m"
 #define _RED "\033[0;31m"

--- a/include/module/manager.h
+++ b/include/module/manager.h
@@ -3,13 +3,13 @@
 #include <string>
 #include <unordered_map>
 #include "ANTLRFileStream.h"
+#include "CommonTokenStream.h"
 #include "FusionLexer.h"
 #include "FusionParser.h"
 #include "ParseTree.h"
 #include "ast/ast.h"
 
 using std::shared_ptr;
-namespace fs = std::filesystem;
 
 namespace module {
 class Unit {

--- a/include/module/manager.h
+++ b/include/module/manager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "ANTLRFileStream.h"
+#include "FusionLexer.h"
+#include "FusionParser.h"
+#include "ParseTree.h"
+#include "ast/ast.h"
+
+using std::shared_ptr;
+namespace fs = std::filesystem;
+
+namespace module {
+class Unit {
+   public:
+    antlr4::tree::ParseTree* tree;
+    Unit(std::string filename);
+    ~Unit();
+
+   private:
+    antlr4::ANTLRFileStream* file;
+    fusion::FusionLexer* lexer;
+    antlr4::CommonTokenStream* tokens;
+    fusion::FusionParser* parser;
+};
+
+class Manager {
+   private:
+    std::unordered_map<std::string, shared_ptr<Unit>> module_cache;
+
+   public:
+    shared_ptr<Unit> compile_unit(std::string module);
+};
+};  // namespace module

--- a/include/shared/context.h
+++ b/include/shared/context.h
@@ -6,7 +6,10 @@
 #include <mlir/IR/Types.h>
 #include <memory>
 #include <stack>
+#include <vector>
 
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
 #include "shared/type/type.h"
 
 using std::shared_ptr, std::make_shared, std::unique_ptr;

--- a/include/shared/type/boolean.h
+++ b/include/shared/type/boolean.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include "mlir/IR/Types.h"
 #include "shared/type/type.h"
 
 class Boolean : public Type {

--- a/include/shared/type/character.h
+++ b/include/shared/type/character.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include "mlir/IR/Types.h"
 #include "shared/type/type.h"
 
 class Character : public Type {

--- a/include/shared/type/float.h
+++ b/include/shared/type/float.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include "mlir/IR/Types.h"
 #include "shared/type/type.h"
 
 class F32 : public Type {

--- a/include/shared/type/integer.h
+++ b/include/shared/type/integer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include "mlir/IR/Types.h"
 #include "shared/type/type.h"
 
 class I32 : public Type {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/shared/type/type.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/shared/context.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/errors/syntax.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/module/manager.cpp"
 )
 
 # Build our executable from the source files.

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -485,3 +485,12 @@ void ast::Continue::xml(int level) {
 void ast::Break::xml(int level) {
     std::cout << std::string(level * 4, ' ') << "</break>\n";
 }
+
+ast::Import::Import(std::string name, Token* token) : Node(token) {
+    this->name = name;
+}
+
+void ast::Import::xml(int level) {
+    std::cout << std::string(level * 4, ' ') << "<import module=\"" << name
+              << "\"/>\n";
+}

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,9 +1,15 @@
 #include "ast/ast.h"
 #include "CommonToken.h"
 #include "shared/context.h"
+#include "shared/type/type.h"
 
+#include <cassert>
 #include <iostream>
+#include <optional>
 #include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 std::string ast::random_name() {
     std::string s = "_";

--- a/src/ast/builder.cpp
+++ b/src/ast/builder.cpp
@@ -28,7 +28,9 @@ shared_ptr<ast::Block> Builder::get_ast() {
 }
 
 std::any Builder::visitFile(FusionParser::FileContext* ctx) {
-    this->ast = std::make_shared<ast::Block>(nullptr);
+    if (this->ast == nullptr) {
+        this->ast = std::make_shared<ast::Block>(nullptr);
+    }
 
     for (auto const& s : ctx->topLevel()) {
         shared_ptr<ast::Node> node = cast_node(ast::Node, visit(s));

--- a/src/ast/builder.cpp
+++ b/src/ast/builder.cpp
@@ -1,11 +1,17 @@
 #include <any>
+#include <cstddef>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "FusionParser.h"
 #include "ast/ast.h"
 #include "ast/builder.h"
+#include "ast/symbol/symbol_table.h"
 #include "errors/errors.h"
 #include "module/manager.h"
 #include "shared/context.h"

--- a/src/ast/builder.cpp
+++ b/src/ast/builder.cpp
@@ -1,4 +1,5 @@
 #include <any>
+#include <iostream>
 #include <stdexcept>
 #include <vector>
 
@@ -6,6 +7,7 @@
 #include "ast/ast.h"
 #include "ast/builder.h"
 #include "errors/errors.h"
+#include "module/manager.h"
 #include "shared/context.h"
 #include "shared/type/type.h"
 
@@ -14,9 +16,12 @@ using std::any_cast;
 #define cast_node(a, b) \
     (dynamic_pointer_cast<a>(any_cast<shared_ptr<ast::Node>>(b)))
 #define to_node(a) static_cast<shared_ptr<ast::Node>>(a)
+#define DEBUG false
 
-Builder::Builder(shared_ptr<SymbolTable> symbol_table) {
+Builder::Builder(shared_ptr<SymbolTable> symbol_table,
+                 shared_ptr<module::Manager> module_manager) {
     this->symbol_table = symbol_table;
+    this->module_manager = module_manager;
 }
 
 bool Builder::has_ast() {
@@ -28,13 +33,14 @@ shared_ptr<ast::Block> Builder::get_ast() {
 }
 
 std::any Builder::visitFile(FusionParser::FileContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering file" << std::endl;
     if (this->ast == nullptr) {
         this->ast = std::make_shared<ast::Block>(nullptr);
     }
 
     for (auto const& s : ctx->topLevel()) {
         shared_ptr<ast::Node> node = cast_node(ast::Node, visit(s));
-
         this->ast->nodes.push_back(node);
     }
 
@@ -42,6 +48,8 @@ std::any Builder::visitFile(FusionParser::FileContext* ctx) {
 }
 
 std::any Builder::visitTopLevel(FusionParser::TopLevelContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering topLevel" << std::endl;
     if (ctx->function() != nullptr) {
         return visit(ctx->function());
     }
@@ -52,10 +60,20 @@ std::any Builder::visitTopLevel(FusionParser::TopLevelContext* ctx) {
         return to_node(decl);
     }
 
+    if (ctx->imp() != nullptr) {
+        return visit(ctx->imp());
+    }
+
+    if (ctx->module() != nullptr) {
+        return visit(ctx->module());
+    }
+
     throw std::runtime_error("found an invalid top level statement");
 }
 
 std::any Builder::visitStatement(FusionParser::StatementContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering statement" << std::endl;
     if (ctx->declaration() != nullptr) {
         return visit(ctx->declaration());
     }
@@ -102,6 +120,8 @@ std::any Builder::visitStatement(FusionParser::StatementContext* ctx) {
 }
 
 std::any Builder::visitDeclaration(FusionParser::DeclarationContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering declaration" << std::endl;
     Token* token = ctx->EQUAL()->getSymbol();
 
     auto expr = cast_node(ast::Expression, visit(ctx->expr()));
@@ -112,6 +132,8 @@ std::any Builder::visitDeclaration(FusionParser::DeclarationContext* ctx) {
 }
 
 std::any Builder::visitType(FusionParser::TypeContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering type" << std::endl;
     auto type = symbol_table->resolve(ctx->getText());
     if (!type.has_value()) {
         throw std::runtime_error("invalid type found");
@@ -121,6 +143,8 @@ std::any Builder::visitType(FusionParser::TypeContext* ctx) {
 }
 
 std::any Builder::visitQualifier(FusionParser::QualifierContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering qualifier" << std::endl;
     if (ctx->CONST() != nullptr) {
         return ast::Qualifier::Const;
     }
@@ -133,6 +157,8 @@ std::any Builder::visitQualifier(FusionParser::QualifierContext* ctx) {
 }
 
 std::any Builder::visitLiteralInt(FusionParser::LiteralIntContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering literalInt" << std::endl;
     Token* token = ctx->INT()->getSymbol();
     std::string str = ctx->INT()->getText();
 
@@ -154,6 +180,8 @@ std::any Builder::visitLiteralInt(FusionParser::LiteralIntContext* ctx) {
 }
 
 std::any Builder::visitLiteralBool(FusionParser::LiteralBoolContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering literalBool" << std::endl;
     Token* token = ctx->BOOLEAN()->getSymbol();
     bool value = true;
     if (ctx->BOOLEAN()->getText() == "false") {
@@ -165,6 +193,8 @@ std::any Builder::visitLiteralBool(FusionParser::LiteralBoolContext* ctx) {
 }
 
 std::any Builder::visitLiteralChar(FusionParser::LiteralCharContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering literalChar" << std::endl;
     std::unordered_map<std::string, char> special_characters = {
         {"\\0", '\0'},  {"\\a", '\a'},  {"\\b", '\b'},
         {"\\t", '\t'},  {"\\n", '\n'},  {"\\r", '\r'},
@@ -185,6 +215,8 @@ std::any Builder::visitLiteralChar(FusionParser::LiteralCharContext* ctx) {
 }
 
 std::any Builder::visitIdentifier(FusionParser::IdentifierContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering identifier" << std::endl;
     Token* token = ctx->ID()->getSymbol();
     std::string name = ctx->ID()->getText();
     TypePtr type = make_shared<Unset>();
@@ -196,6 +228,8 @@ std::any Builder::visitIdentifier(FusionParser::IdentifierContext* ctx) {
 }
 
 std::any Builder::visitBlock(FusionParser::BlockContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering block" << std::endl;
     Token* token = ctx->L_CURLY()->getSymbol();
     auto block = make_shared<ast::Block>(token);
 
@@ -209,6 +243,8 @@ std::any Builder::visitBlock(FusionParser::BlockContext* ctx) {
 }
 
 std::any Builder::visitVariable(FusionParser::VariableContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering variable" << std::endl;
     Token* token = ctx->ID()->getSymbol();
     std::string name = ctx->ID()->getText();
 
@@ -221,6 +257,8 @@ std::any Builder::visitVariable(FusionParser::VariableContext* ctx) {
 }
 
 std::any Builder::visitFunction(FusionParser::FunctionContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering function" << std::endl;
     Token* token = ctx->FUNCTION()->getSymbol();
     TypePtr type = any_cast<TypePtr>(visit(ctx->type()));
     std::string name = ctx->ID()->getText();
@@ -238,6 +276,8 @@ std::any Builder::visitFunction(FusionParser::FunctionContext* ctx) {
 }
 
 std::any Builder::visitCall(FusionParser::CallContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering call" << std::endl;
     Token* token = ctx->L_PAREN()->getSymbol();
     std::string name = ctx->ID()->getText();
     std::vector<shared_ptr<ast::Expression>> args;
@@ -251,10 +291,14 @@ std::any Builder::visitCall(FusionParser::CallContext* ctx) {
 }
 
 std::any Builder::visitCallExpr(FusionParser::CallExprContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering callExpr" << std::endl;
     return visit(ctx->call());
 }
 
 std::any Builder::visitReturn(FusionParser::ReturnContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering return" << std::endl;
     Token* token = ctx->RETURN()->getSymbol();
     auto expr = cast_node(ast::Expression, visit(ctx->expr()));
     auto ret = make_shared<ast::Return>(expr, token);
@@ -263,6 +307,8 @@ std::any Builder::visitReturn(FusionParser::ReturnContext* ctx) {
 }
 
 std::any Builder::visitPower(FusionParser::PowerContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering power" << std::endl;
     Token* token = ctx->CARET()->getSymbol();
     auto lhs = cast_node(ast::Expression, visit(ctx->expr()[0]));
     auto rhs = cast_node(ast::Expression, visit(ctx->expr()[1]));
@@ -273,6 +319,8 @@ std::any Builder::visitPower(FusionParser::PowerContext* ctx) {
 }
 
 std::any Builder::visitMulDivMod(FusionParser::MulDivModContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering mulDivMod" << std::endl;
     Token* token;
     ast::BinaryOpType type;
 
@@ -297,6 +345,8 @@ std::any Builder::visitMulDivMod(FusionParser::MulDivModContext* ctx) {
 }
 
 std::any Builder::visitAddSub(FusionParser::AddSubContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering addSub" << std::endl;
     Token* token;
     ast::BinaryOpType type;
 
@@ -317,6 +367,8 @@ std::any Builder::visitAddSub(FusionParser::AddSubContext* ctx) {
 }
 
 std::any Builder::visitGtLtCond(FusionParser::GtLtCondContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering gtLtCond" << std::endl;
     Token* token;
     ast::BinaryOpType type;
 
@@ -343,6 +395,8 @@ std::any Builder::visitGtLtCond(FusionParser::GtLtCondContext* ctx) {
 }
 
 std::any Builder::visitEqNeCond(FusionParser::EqNeCondContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering eqNeCond" << std::endl;
     Token* token;
     ast::BinaryOpType type;
 
@@ -363,6 +417,8 @@ std::any Builder::visitEqNeCond(FusionParser::EqNeCondContext* ctx) {
 }
 
 std::any Builder::visitAndOrCond(FusionParser::AndOrCondContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering andOrCond" << std::endl;
     Token* token;
     ast::BinaryOpType type;
 
@@ -383,6 +439,8 @@ std::any Builder::visitAndOrCond(FusionParser::AndOrCondContext* ctx) {
 }
 
 std::any Builder::visitUnary(FusionParser::UnaryContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering unary" << std::endl;
     Token* token;
     ast::UnaryOpType type;
 
@@ -402,6 +460,8 @@ std::any Builder::visitUnary(FusionParser::UnaryContext* ctx) {
 }
 
 std::any Builder::visitAssignment(FusionParser::AssignmentContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering assignment" << std::endl;
     Token* token = ctx->ID()->getSymbol();
     std::string name = ctx->ID()->getText();
     TypePtr type = make_shared<Unset>();
@@ -413,7 +473,10 @@ std::any Builder::visitAssignment(FusionParser::AssignmentContext* ctx) {
     auto assn = make_shared<ast::Assignment>(var, expr, token);
     return to_node(assn);
 }
+
 std::any Builder::visitIf(FusionParser::IfContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering if" << std::endl;
     Token* token = ctx->IF()->getSymbol();
 
     auto condition = cast_node(ast::Expression, visit(ctx->expr()));
@@ -429,6 +492,8 @@ std::any Builder::visitIf(FusionParser::IfContext* ctx) {
 }
 
 std::any Builder::visitElse(FusionParser::ElseContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering else" << std::endl;
     Token* token = ctx->ELSE()->getSymbol();
 
     if (ctx->if_() != nullptr) {
@@ -442,6 +507,8 @@ std::any Builder::visitElse(FusionParser::ElseContext* ctx) {
 }
 
 std::any Builder::visitLoop(FusionParser::LoopContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering loop" << std::endl;
     Token* token = ctx->FOR()->getSymbol();
 
     auto variable = cast_node(ast::Declaration, visit(ctx->declaration()));
@@ -451,5 +518,25 @@ std::any Builder::visitLoop(FusionParser::LoopContext* ctx) {
 
     auto node =
         make_shared<ast::Loop>(variable, condition, assignment, body, token);
+    return to_node(node);
+}
+
+std::any Builder::visitModule(FusionParser::ModuleContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering module" << std::endl;
+    std::string name = ctx->ID()->getText();
+    // shared_ptr<ast::Node> ast = get_module(name);
+
+    return nullptr;
+}
+
+std::any Builder::visitImp(FusionParser::ImpContext* ctx) {
+    if (DEBUG)
+        std::cout << "entering imp" << std::endl;
+    std::string name = ctx->ID()->getText();
+    shared_ptr<module::Unit> unit = module_manager->compile_unit(name);
+    visit(unit->tree);
+
+    auto node = make_shared<ast::Import>(name, ctx->ID()->getSymbol());
     return to_node(node);
 }

--- a/src/ast/passes/builtin.cpp
+++ b/src/ast/passes/builtin.cpp
@@ -1,5 +1,13 @@
 #include "ast/passes/builtin.h"
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include "ast/ast.h"
+#include "ast/passes/pass.h"
 #include "ast/symbol/function_symbol.h"
+#include "ast/symbol/symbol.h"
+#include "ast/symbol/symbol_table.h"
 
 Builtin::Builtin(shared_ptr<SymbolTable> symbol_table) : Pass("Builtin") {
     this->symbol_table = symbol_table;

--- a/src/ast/passes/control_flow.cpp
+++ b/src/ast/passes/control_flow.cpp
@@ -1,4 +1,6 @@
 #include "ast/passes/control_flow.h"
+#include "ast/ast.h"
+#include "ast/passes/pass.h"
 #include "errors/errors.h"
 
 ControlFlow::ControlFlow() : Pass("Control Flow") {

--- a/src/ast/passes/def_ref.cpp
+++ b/src/ast/passes/def_ref.cpp
@@ -1,6 +1,13 @@
 #include "ast/passes/def_ref.h"
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
 #include "ast/ast.h"
+#include "ast/passes/pass.h"
 #include "ast/symbol/function_symbol.h"
+#include "ast/symbol/symbol.h"
+#include "ast/symbol/symbol_table.h"
 #include "errors/errors.h"
 
 DefRef::DefRef(shared_ptr<SymbolTable> symbol_table) : Pass("DefRef") {

--- a/src/ast/passes/pass.cpp
+++ b/src/ast/passes/pass.cpp
@@ -57,7 +57,7 @@ void Pass::visit(shared_ptr<ast::Node> node) {
     try_visit(node, ast::Loop, this->visit_loop);
     try_visit(node, ast::Continue, this->visit_continue);
     try_visit(node, ast::Break, this->visit_break);
-
+    try_visit(node, ast::Import, this->visit_import);
     throw std::runtime_error("node not added to pass manager");
 }
 
@@ -127,3 +127,5 @@ void Pass::visit_loop(shared_ptr<ast::Loop> node) {
     visit(node->assignment);
     visit(node->body);
 }
+
+void Pass::visit_import(shared_ptr<ast::Import> node) {}

--- a/src/ast/passes/pass.cpp
+++ b/src/ast/passes/pass.cpp
@@ -1,9 +1,16 @@
 #include "ast/passes/pass.h"
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 #include "ast/ast.h"
 #include "ast/passes/builtin.h"
 #include "ast/passes/control_flow.h"
 #include "ast/passes/def_ref.h"
 #include "ast/passes/type_check.h"
+#include "ast/symbol/symbol_table.h"
 
 constexpr bool debug = false;
 #define try_visit(node, t, f)                                    \

--- a/src/ast/passes/type_check.cpp
+++ b/src/ast/passes/type_check.cpp
@@ -1,7 +1,10 @@
 #include "ast/passes/type_check.h"
+#include <cstddef>
 #include "ast/ast.h"
+#include "ast/passes/pass.h"
 #include "errors/errors.h"
 #include "shared/context.h"
+#include "shared/type/type.h"
 
 TypeCheck::TypeCheck() : Pass("Typecheck") {}
 

--- a/src/ast/symbol/function_symbol.cpp
+++ b/src/ast/symbol/function_symbol.cpp
@@ -1,4 +1,7 @@
 #include "ast/symbol/function_symbol.h"
+#include "ast/ast.h"
+#include "ast/symbol/scope.h"
+#include "ast/symbol/symbol.h"
 
 FunctionSymbol::FunctionSymbol(shared_ptr<ast::Function> function,
                                ScopePtr enclosing_scope)

--- a/src/ast/symbol/scope.cpp
+++ b/src/ast/symbol/scope.cpp
@@ -1,4 +1,7 @@
 #include "ast/symbol/scope.h"
+#include <optional>
+#include <string>
+#include "ast/symbol/symbol.h"
 
 Scope::Scope(ScopePtr enclosing_scope) {
     this->enclosing_scope = enclosing_scope;

--- a/src/ast/symbol/symbol.cpp
+++ b/src/ast/symbol/symbol.cpp
@@ -1,4 +1,7 @@
 #include "ast/symbol/symbol.h"
+#include <string>
+#include "ast/ast.h"
+#include "shared/type/type.h"
 
 Symbol::Symbol(std::string name) : Symbol(name, nullptr) {}
 

--- a/src/ast/symbol/symbol_table.cpp
+++ b/src/ast/symbol/symbol_table.cpp
@@ -1,11 +1,16 @@
 #include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "CommonToken.h"
 #include "ast/ast.h"
 #include "ast/symbol/function_symbol.h"
+#include "ast/symbol/scope.h"
 #include "ast/symbol/symbol.h"
 #include "ast/symbol/symbol_table.h"
 #include "shared/context.h"
+#include "shared/type/type.h"
 
 namespace {
 shared_ptr<ast::Function> make_print(TypePtr type) {

--- a/src/backend/builtin/print.cpp
+++ b/src/backend/builtin/print.cpp
@@ -1,10 +1,15 @@
 #include "backend/builtin/print.h"
+#include <string>
 #include "backend/io.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 #include "shared/context.h"
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/Block.h"
+#include "shared/type/type.h"
 
 namespace {
 void create_type_str(TypePtr type) {

--- a/src/backend/visitor.cpp
+++ b/src/backend/visitor.cpp
@@ -38,6 +38,7 @@ mlir::Value Backend::visit(shared_ptr<ast::Node> node) {
     try_visit(node, ast::Loop, this->visit_loop);
     try_visit(node, ast::Continue, this->visit_continue);
     try_visit(node, ast::Break, this->visit_break);
+    try_visit(node, ast::Import, this->visit_import);
 
     throw std::runtime_error("node not added to backend visit function");
 }
@@ -272,5 +273,9 @@ mlir::Value Backend::visit_break(shared_ptr<ast::Break> node) {
 
     ctx::builder->setInsertionPointToStart(b_body);
 
+    return nullptr;
+}
+
+mlir::Value Backend::visit_import(shared_ptr<ast::Import> node) {
     return nullptr;
 }

--- a/src/backend/visitor.cpp
+++ b/src/backend/visitor.cpp
@@ -1,4 +1,8 @@
+#include <cstddef>
 #include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "ast/ast.h"
 #include "backend/backend.h"
@@ -11,6 +15,8 @@
 
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "shared/context.h"
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1,41 +1,11 @@
 #include <cassert>
+#include <filesystem>
 
-#include "ANTLRFileStream.h"
-#include "CommonTokenStream.h"
-#include "FusionLexer.h"
-#include "FusionParser.h"
 #include "ast/passes/pass.h"
 #include "compiler.h"
 #include "errors/errors.h"
-#include "errors/syntax.h"
 
-Unit::Unit(std::string filename,
-           LexerErrorListener* lexer_error,
-           SyntaxErrorListener* syntax_error) {
-    file = new antlr4::ANTLRFileStream();
-    file->loadFromFile(filename);
-
-    lexer = new fusion::FusionLexer(file);
-    lexer->removeErrorListeners();
-    lexer->addErrorListener(lexer_error);
-
-    tokens = new antlr4::CommonTokenStream(lexer);
-
-    parser = new fusion::FusionParser(tokens);
-    parser->removeErrorListeners();
-    parser->addErrorListener(syntax_error);
-
-    tree = parser->file();
-}
-
-Unit::~Unit() {
-    delete file;
-    delete lexer;
-    delete tokens;
-    delete parser;
-}
-
-Compiler::Compiler(std::vector<std::string> filenames,
+Compiler::Compiler(fs::path entry,
                    shared_ptr<SymbolTable> symbol_table,
                    unique_ptr<Backend> backend,
                    unique_ptr<Builder> builder) {
@@ -43,13 +13,7 @@ Compiler::Compiler(std::vector<std::string> filenames,
     this->backend = std::move(backend);
     this->builder = std::move(builder);
 
-    lexer_error = new LexerErrorListener();
-    syntax_error = new SyntaxErrorListener();
-
-    for (const auto& filename : filenames) {
-        auto unit = make_shared<Unit>(filename, lexer_error, syntax_error);
-        this->units.push_back(unit);
-    }
+    this->entry = make_shared<module::Unit>(entry);
 }
 
 Compiler::~Compiler() {
@@ -58,14 +22,12 @@ Compiler::~Compiler() {
 }
 
 void Compiler::build_ast() {
-    for (const auto& unit : units) {
-        try {
-            builder->visit(unit->tree);
-            assert(builder->has_ast());
-        } catch (CompileTimeException const& e) {
-            std::cerr << e.what() << std::endl;
-            exit(1);
-        }
+    try {
+        builder->visit(entry->tree);
+        assert(builder->has_ast());
+    } catch (CompileTimeException const& e) {
+        std::cerr << e.what() << std::endl;
+        exit(1);
     }
 }
 

--- a/src/errors/syntax.cpp
+++ b/src/errors/syntax.cpp
@@ -1,5 +1,15 @@
 #include "errors/syntax.h"
+#include "CommonTokenStream.h"
+#include "Parser.h"
+#include "Recognizer.h"
+#include "Token.h"
+#include <cstddef>
+#include <exception>
+#include <ostream>
+#include <sstream>
+#include <string>
 #include "errors/errors.h"
+#include "antlr4-runtime.h"
 
 void SyntaxErrorListener::syntaxError(antlr4::Recognizer* recognizer,
                                       antlr4::Token* offending_symbol,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,11 +16,21 @@ int main(int argc, char** argv) {
     shared_ptr<SymbolTable> symbol_table = make_shared<SymbolTable>();
     unique_ptr<Builder> builder = make_unique<Builder>(symbol_table);
     unique_ptr<Backend> backend = make_unique<Backend>();
-    Compiler compiler =
-        Compiler(argv[1], symbol_table, std::move(backend), std::move(builder));
+
+    std::vector<std::string> filenames;
+    for (size_t i = 1; i < argc; i++) {
+        std::string arg = std::string(argv[i]);
+        if (arg[0] == '-') {
+            break;
+        }
+
+        filenames.push_back(arg);
+    }
+    Compiler compiler = Compiler(filenames, symbol_table, std::move(backend),
+                                 std::move(builder));
 
     compiler.build_ast();
-    for (size_t i = 0; i < argc; i++) {
+    for (size_t i = 1; i < argc; i++) {
         std::string arg = std::string(argv[i]);
         if (arg == "--xml") {
             compiler.xml();
@@ -28,7 +38,7 @@ int main(int argc, char** argv) {
     }
 
     compiler.run_passes();
-    for (size_t i = 0; i < argc; i++) {
+    for (size_t i = 1; i < argc; i++) {
         std::string arg = std::string(argv[i]);
         if (arg == "--pass-xml") {
             compiler.xml();
@@ -36,7 +46,7 @@ int main(int argc, char** argv) {
     }
 
     compiler.build_backend();
-    for (size_t i = 0; i < argc; i++) {
+    for (size_t i = 1; i < argc; i++) {
         std::string arg = std::string(argv[i]);
         if (arg == "--emit-llvm" && i == argc - 1) {
             std::cerr << "You must provide a file emit llvm ir to" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "ast/symbol/symbol_table.h"
 #include "backend/backend.h"
 #include "compiler.h"
+#include "module/manager.h"
 #include "shared/context.h"
 
 #include <iostream>
@@ -11,23 +12,21 @@
 using std::shared_ptr, std::unique_ptr, std::make_shared, std::make_unique;
 
 int main(int argc, char** argv) {
-    ctx::initialize_context();
+    if (argc < 2) {
+        std::cerr << "must provide an entry point file" << std::endl;
+        exit(1);
+    }
 
+    ctx::initialize_context();
     shared_ptr<SymbolTable> symbol_table = make_shared<SymbolTable>();
-    unique_ptr<Builder> builder = make_unique<Builder>(symbol_table);
+    shared_ptr<module::Manager> module_manager = make_shared<module::Manager>();
+    unique_ptr<Builder> builder =
+        make_unique<Builder>(symbol_table, module_manager);
     unique_ptr<Backend> backend = make_unique<Backend>();
 
-    std::vector<std::string> filenames;
-    for (size_t i = 1; i < argc; i++) {
-        std::string arg = std::string(argv[i]);
-        if (arg[0] == '-') {
-            break;
-        }
-
-        filenames.push_back(arg);
-    }
-    Compiler compiler = Compiler(filenames, symbol_table, std::move(backend),
-                                 std::move(builder));
+    std::string entry = std::string(argv[1]);
+    Compiler compiler =
+        Compiler(entry, symbol_table, std::move(backend), std::move(builder));
 
     compiler.build_ast();
     for (size_t i = 1; i < argc; i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,14 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 using std::shared_ptr, std::unique_ptr, std::make_shared, std::make_unique;
 
 int main(int argc, char** argv) {
     if (argc < 2) {
         std::cerr << "must provide an entry point file" << std::endl;
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     ctx::initialize_context();

--- a/src/module/manager.cpp
+++ b/src/module/manager.cpp
@@ -1,4 +1,10 @@
 #include "module/manager.h"
+#include <string>
+#include "ANTLRFileStream.h"
+#include "CommonTokenStream.h"
+#include "FusionLexer.h"
+#include "FusionParser.h"
+#include "ast/ast.h"
 #include "errors/syntax.h"
 
 module::Unit::Unit(std::string filename) {

--- a/src/module/manager.cpp
+++ b/src/module/manager.cpp
@@ -1,0 +1,41 @@
+#include "module/manager.h"
+#include "errors/syntax.h"
+
+module::Unit::Unit(std::string filename) {
+    auto lexer_error = new LexerErrorListener();
+    auto syntax_error = new SyntaxErrorListener();
+
+    file = new antlr4::ANTLRFileStream();
+    file->loadFromFile(filename);
+
+    lexer = new fusion::FusionLexer(file);
+    lexer->removeErrorListeners();
+    lexer->addErrorListener(lexer_error);
+
+    tokens = new antlr4::CommonTokenStream(lexer);
+
+    parser = new fusion::FusionParser(tokens);
+    parser->removeErrorListeners();
+    parser->addErrorListener(syntax_error);
+
+    tree = parser->file();
+}
+
+module::Unit::~Unit() {
+    delete file;
+    delete lexer;
+    delete tokens;
+    delete parser;
+}
+
+shared_ptr<module::Unit> module::Manager::compile_unit(std::string module) {
+    auto m = module_cache.find(module);
+    if (m != module_cache.end()) {
+        return m->second;
+    }
+
+    auto unit = make_shared<module::Unit>(module + ".fuse");
+    module_cache[module] = unit;
+
+    return unit;
+}


### PR DESCRIPTION
## Current Implementation
- Can import any file within the same folder
- File must end in `.fuse` and the import must match the filename
- Cannot have multiple files with the same module

## Future Implementation
- Multiple files can be within the same module
- Auto search for files within nested directories
- Throws error if module not defined
- When accessing method `bar()` from module `foo` it should be accessed with `foo.bar()`